### PR TITLE
New inputs 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -108,5 +108,5 @@ This command will create a virtual python enviroment, compile, and execute the p
 
 - Push the image to `dockerhub:
     ```bash
-    podman push localhost/state-diff-commitment:latest docker.io/username/state-diff-commitment:latest
+    podman push localhost/state-diff-commitment:latest docker.io/<USERNAME>/state-diff-commitment:latest
     ```

--- a/README.MD
+++ b/README.MD
@@ -58,3 +58,29 @@ To execute the program, run the `run.sh` script in the root directory. If you wa
 ```
 
 This command will create a virtual python enviroment, compile, and execute the program with the provided input and display the resulting `genesis_state_hash` and `new_state_hash`.
+
+## Building and publishing the image
+
+```bash
+podman build -t stone5-poseidon3 -f prover.dockerfile .
+```
+
+```bash
+podman push localhost/stone5-poseidon3:latest docker.io/username/stone5-poseidon3:latest
+```
+
+```bash
+podman build -t example-program -f example-program.dockerfile .
+```
+
+```bash
+podman run -i --rm example-program < program_input.json > proof.json
+```
+
+```bash
+podman run -i --rm verifier < proof.json
+```
+
+```bash
+podman push localhost/verifier:latest docker.io/username/verifier:latest
+```

--- a/README.MD
+++ b/README.MD
@@ -61,26 +61,15 @@ This command will create a virtual python enviroment, compile, and execute the p
 
 ## Building and publishing the image
 
-```bash
-podman build -t stone5-poseidon3 -f prover.dockerfile .
-```
+- Build the image:
 
-```bash
-podman push localhost/stone5-poseidon3:latest docker.io/username/stone5-poseidon3:latest
-```
+    ```bash
+    podman build -t state-diff-commitment .
+    ```
 
-```bash
-podman build -t example-program -f example-program.dockerfile .
-```
+    When asked about the `stone5-poseidon3` image select the `docker.io` version
 
-```bash
-podman run -i --rm example-program < program_input.json > proof.json
-```
-
-```bash
-podman run -i --rm verifier < proof.json
-```
-
-```bash
-podman push localhost/verifier:latest docker.io/username/verifier:latest
-```
+- Push the image to `dockerhub:
+    ```bash
+    podman push localhost/state-diff-commitment:latest docker.io/username/state-diff-commitment:latest
+    ```

--- a/README.MD
+++ b/README.MD
@@ -6,8 +6,13 @@ This repository contains a provable cairo program that computes the hash of a st
 
 The input format consists of the following components:
 
-- `genesis_state_hash`
-- `prev_state_hash`
+<!-- TODO: Add descruotuib to these fields -->
+- `prev_state_root`
+- `block_number`
+- `block_hash`
+- `config_hash`
+- `message_to_starknet_segment`
+- `message_to_appchain_segment`
 - `nonce_updates`: A mapping of contract addresses to their updated nonces.
 - `storage_updates`: A mapping of contract addresses to their updated storage entries.
 - `contract_updates`: A mapping of contract addresses to their updated class hashes.
@@ -20,8 +25,18 @@ To illustrate the input format, consider the following JSON representation:
 
 ```json
 {
-    "genesis_state_hash": 12312321313,
-    "prev_state_hash": 34343434343,
+    "prev_state_root": 34343434343,
+    "block_number": 123456,
+    "block_hash": 1234567890,
+    "config_hash": 1234567890,
+    "message_to_starknet_segment": [
+        123,
+        " ... "
+    ],
+    "message_to_appchain_segment": [
+        123,
+        " ... "
+    ],
     "nonce_updates": {
         "7589307": 12,
         " ... "
@@ -45,7 +60,29 @@ To illustrate the input format, consider the following JSON representation:
 
 ## Output
 
-The program outputs two numbers: `(genesis_state_hash, new_state_hash)`.
+The program outputs:
+```cairo
+struct ProgramOutput {
+    /// The state commitment before this block.
+    prev_state_root: felt252,
+    /// The state commitment after this block.
+    new_state_root: felt252,
+    /// The number (height) of this block.
+    block_number: felt252,
+    /// The hash of this block.
+    block_hash: felt252,
+    /// The Starknet chain config hash
+    config_hash: felt252,
+    /// Currently, as the SNOS output is not using the cairo
+    /// serialization, we can only have a felt252 array with the
+    /// messages segments.
+    message_to_starknet_segment: Array<felt252>,
+    message_to_appchain_segment: Array<felt252>,
+}
+```
+serialized to a felt array. 
+
+All the fields except for `new_state_root` are copied from the input. The `new_state_root` is a hash over the input.
 
 ## How to Run
 

--- a/README.MD
+++ b/README.MD
@@ -7,10 +7,10 @@ This repository contains a provable cairo program that computes the hash of a st
 The input format consists of the following components:
 
 <!-- TODO: Add descruotuib to these fields -->
-- `prev_state_root`
-- `block_number`
-- `block_hash`
-- `config_hash`
+- `prev_state_root`: The state commitment before this block.
+- `block_number`: The number (height) of this block.
+- `block_hash`: The hash of this block.
+- `config_hash`: The Starknet chain config hash.
 - `message_to_starknet_segment`
 - `message_to_appchain_segment`
 - `nonce_updates`: A mapping of contract addresses to their updated nonces.
@@ -106,7 +106,7 @@ This command will create a virtual python enviroment, compile, and execute the p
 
     When asked about the `stone5-poseidon3` image select the `docker.io` version
 
-- Push the image to `dockerhub:
+- Push the image to `dockerhub`:
     ```bash
     podman push localhost/state-diff-commitment:latest docker.io/<USERNAME>/state-diff-commitment:latest
     ```

--- a/src/input.json
+++ b/src/input.json
@@ -1,6 +1,20 @@
 {
-    "genesis_state_hash": 12312321313,
-    "prev_state_hash": 34343434343,
+    "prev_state_root": 34343434343,
+    "block_number": 123456,
+    "block_hash": 1234567890,
+    "config_hash": 1234567890,
+    "message_to_starknet_segment": [
+        123,
+        456,
+        123,
+        128
+    ],
+    "message_to_appchain_segment": [
+        123,
+        456,
+        123,
+        128
+    ],
     "nonce_updates": {
         "1": 12,
         "2": 1337


### PR DESCRIPTION
Support new input and output types as described in https://github.com/dojoengine/dojo/issues/1723.

The example input is in `src/input.json` and the output is:
```cairo
struct ProgramOutput {
    /// The state commitment before this block.
    prev_state_root: felt252,
    /// The state commitment after this block.
    new_state_root: felt252,
    /// The number (height) of this block.
    block_number: felt252,
    /// The hash of this block.
    block_hash: felt252,
    /// The Starknet chain config hash
    config_hash: felt252,
    /// Currently, as the SNOS output is not using the cairo
    /// serialization, we can only have a felt252 array with the
    /// messages segments.
    message_to_starknet_segment: Array<felt252>,
    message_to_appchain_segment: Array<felt252>,
}
```
serialized to a felt array. 

All the fields except for `new_state_root` are simply copied from the input. The `new_state_root` is a hash over the input.